### PR TITLE
chore: use self-hosted Linux X64 runner for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   dependabot-triage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER && fromJSON('["self-hosted", "Linux", "X64"]') || fromJSON('["ubuntu-latest"]') }}
     if: github.actor == 'dependabot[bot]'
 
     permissions:


### PR DESCRIPTION
## Summary
- Switch dependabot workflow runner from `ubuntu-latest` to self-hosted Linux X64 (with `ubuntu-latest` fallback if `CI_RUNNER` var is not set)

## Test plan
- [ ] Verify workflow runs on self-hosted runner after merge