### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
Node 24-ready checkout ahead of GitHub's 2026-06-16 forced migration. Version-string-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)