### PR TITLE
ci: bump deprecated Node-20 actions to Node-24 majors

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           alert-lookup: true


### PR DESCRIPTION
## Bumped actions

| Action | From | To | Reason |
|--------|------|----|--------|
| `actions/setup-node` | v4 (node20) | v5 (node24) | Lowest node24 major |
| `dependabot/fetch-metadata` | v2 (node20) | v3 (node24) | Lowest node24 major |

## Left as-is

| Action | Version | Reason |
|--------|---------|--------|
| `fastify/github-action-merge-dependabot` | v3 | Uses `composite` runner — not subject to Node runtime deprecation |
| `actions/checkout` | v6 | Already node24 — no change needed |

## Context

GitHub is forcing Node-20 actions onto the Node-24 runtime on 2026-06-16. This PR bumps all affected actions to their lowest available Node-24-runtime major to minimise breaking-change risk.

> **Do not merge** — review only.