### PR TITLE
Fix duplicate -- in amplify build command

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -14,7 +14,7 @@ applications:
             - pnpm install --frozen-lockfile
         build:
           commands:
-            - pnpm run build -- --configuration=${BUILD_CONFIG:-production}
+            - pnpm run build --configuration=${BUILD_CONFIG:-production}
       artifacts:
         baseDirectory: dist/browser
         files:


### PR DESCRIPTION
Fixes duplicate -- in amplify.yml build command causing SchemaValidationError: Data path '' must NOT have additional properties(). Removed the extra -- from the pnpm run build command in amplify.yml so that only one -- is passed from the Amplify build command.